### PR TITLE
Fix to avoid decoding None type value when _send_and_recv() is failed

### DIFF
--- a/src/omronfins/finsudp.py
+++ b/src/omronfins/finsudp.py
@@ -103,6 +103,8 @@ class FinsAbstruct():
         msg = self._datacreator.command_read_mem_area(
                 mem_area, addr, bit, num)
         ret_id, bin_msg = self._send_and_recv(msg)
+        if ret_id < 0:
+            return ret_id, None
         return self._datacreator.decode_read_data(bin_msg, dtype)
 
     def write_mem_area(self, mem_area, addr, bit, num, values):


### PR DESCRIPTION
Long time no see.

By the way, we found an error when `_send_and_recv()` returns a negative value as a return code.
This ends up to get such an exception below.

```bash
Traceback (most recent call last):
 .local/lib/python3.8/site-packages/omronfins/datacreator.py", line 215, in decode_read_data
     ret_id = struct.unpack('!H', data[12:14])[0]
 TypeError: 'NoneType' object is not subscriptable
```

I think we should return without trying to decode when fails to receive data from PLC.

Could you consider to merge this PR? Thank you in advance.